### PR TITLE
Py37 Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
 matrix:
   allow-failures:
     - env: TOXENV=vulture
+      stage: lint
 
 
 # 1. apt addons

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 # Organize the .travis.yml by the steps in the build lifecycle
 # https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle
 
-# 0. language and environment
+# 0. language and build environment
 language: python
 
-python: 3.7
+python:
+  - 3.7
+  - 3.6
 dist: xenial
 sudo: true
 
+services: postgresql
+
 
 # 0.5 jobs, stages, and matrix
+env:
+  - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
+  - TOXENV=py DB=sqlite
+
 jobs:
   include:
     # lint stage
@@ -24,23 +32,6 @@ jobs:
       env: TOXENV=doc8
     - env: TOXENV=readme
     - env: TOXENV=docs
-
-    # test stage
-    - stage: test
-      env: TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
-      services: postgresql
-    - env: TOXENV=py DB=sqlite
-
-    - env: TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
-      services: postgresql
-      python: 3.6
-      dist: trusty
-      sudo: false
-    - env: TOXENV=py DB=sqlite
-      services: postgresql
-      python: 3.6
-      dist: trusty
-      sudo: false
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,8 @@ jobs:
     - env: TOXENV=py DB=sqlite
 
 matrix:
-  allow-failures:
+  allow_failures:
     - env: TOXENV=vulture
-      stage: lint
 
 
 # 1. apt addons

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ cache: pip
 
 # 4. install
 install:
-    - pip install tox codecov coverage
+    - pip install tox coverage codecov
 
 
 # 5. before_script

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@
 # 0. language and environment
 language: python
 
-python: "3.7"
-dist: xenial
-sudo: true
-
-
 # 0.5 jobs, stages, and matrix
 env:
   - TOXENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,27 +9,24 @@ dist: xenial
 sudo: true
 
 
-# 0.5 jobs and matrix
+# 0.5 jobs, stages, and matrix
+env:
+  - TOXENV=flake8
+  - TOXENV=manifest
+  - TOXENV=mypy
+  - TOXENV=vulture
+  - TOXENV=doc8
+  - TOXENV=readme
+  - TOXENV=docs
+  - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
+  - TOXENV=py DB=sqlite
+
 jobs:
   include:
-    # lint stage
-    - stage: lint
-      env: TOXENV=flake8
-    - env: TOXENV=manifest
-    - env: TOXENV=mypy
-    - env: TOXENV=vulture
-
-    # docs stage
-    - stage: docs
-      env: TOXENV=doc8
-    - env: TOXENV=readme
-    - env: TOXENV=docs
-
-    # test stage
-    - stage: test
-      env: TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
-      services: postgresql
-    - env: TOXENV=py DB=sqlite
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 matrix:
   allow_failures:
@@ -69,8 +66,7 @@ script:
 
 # 8. after_success/after_failure
 after_success:
-    - tox -e coverage-report
-    - codecov
+    - sh -c 'if [ "$TOXENV" = "py" ]; then tox -e coverage-report; codecov; fi'
 
 
 # 9. before_deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ python:
 dist: xenial
 sudo: true
 
+services: postgresql
+
 
 # 0.5 jobs, stages, and matrix
 stages:
@@ -19,7 +21,6 @@ stages:
 
 env:
   - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
-    services: postgresql
   - TOXENV=py DB=sqlite
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ python:
 dist: xenial
 sudo: true
 
-services: postgresql
-
 
 # 0.5 jobs, stages, and matrix
 stages:
@@ -21,6 +19,7 @@ stages:
 
 env:
   - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
+    services: postgresql
   - TOXENV=py DB=sqlite
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ services: postgresql
 
 
 # 0.5 jobs, stages, and matrix
+stages:
+  - lint
+  - docs
+  - test
+
 env:
   - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
   - TOXENV=py DB=sqlite
@@ -34,6 +39,10 @@ jobs:
     - env: TOXENV=docs
 
 matrix:
+  include:
+    - python: 3.6
+      dist: trusty
+      sudo: false
   allow_failures:
     - env: TOXENV=vulture
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle
 
 # 0. language and environment
-langauge: python
+language: python
 
 python: "3.7"
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,6 @@ jobs:
     - env: TOXENV=docs
 
 matrix:
-  include:
-    - python: 3.6
-      dist: trusty
-      sudo: false
   allow_failures:
     - env: TOXENV=vulture
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,37 @@ sudo: true
 
 
 # 0.5 jobs, stages, and matrix
-env:
-  - TOXENV=flake8
-  - TOXENV=manifest
-  - TOXENV=mypy
-  - TOXENV=vulture
-  - TOXENV=doc8
-  - TOXENV=readme
-  - TOXENV=docs
-  - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
-  - TOXENV=py DB=sqlite
+jobs:
+  include:
+    # lint stage
+    - stage: lint
+      env: TOXENV=flake8
+    - env: TOXENV=manifest
+    - env: TOXENV=mypy
+    - env: TOXENV=vulture
+
+    # docs stage
+    - stage: docs
+      env: TOXENV=doc8
+    - env: TOXENV=readme
+    - env: TOXENV=docs
+
+    # test stage
+    - stage: test
+      env: TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
+      services: postgresql
+    - env: TOXENV=py DB=sqlite
+
+    - env: TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
+      services: postgresql
+      python: 3.6
+      dist: trusty
+      sudo: false
+    - env: TOXENV=py DB=sqlite
+      services: postgresql
+      python: 3.6
+      dist: trusty
+      sudo: false
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@
 language: python
 
 # 0.5 jobs, stages, and matrix
-env:
-  - TOXENV=flake8
-  - TOXENV=manifest
-  - TOXENV=mypy
-  - TOXENV=vulture
-  - TOXENV=doc8
-  - TOXENV=readme
-  - TOXENV=docs
-  - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
-  - TOXENV=py DB=sqlite
+# env:
+#   - TOXENV=flake8
+#   - TOXENV=manifest
+#   - TOXENV=mypy
+#   - TOXENV=vulture
+#   - TOXENV=doc8
+#   - TOXENV=readme
+#   - TOXENV=docs
+#   - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
+#   - TOXENV=py DB=sqlite
 
 jobs:
   include:
@@ -53,7 +53,9 @@ before_script:
 
 # 6. script
 script:
-    - tox
+    # - tox
+    - python --version
+    - pip --version
 
 
 # 7. before_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,22 @@
 # 0. language and environment
 language: python
 
-# 0.5 jobs, stages, and matrix
-# env:
-#   - TOXENV=flake8
-#   - TOXENV=manifest
-#   - TOXENV=mypy
-#   - TOXENV=vulture
-#   - TOXENV=doc8
-#   - TOXENV=readme
-#   - TOXENV=docs
-#   - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
-#   - TOXENV=py DB=sqlite
+python: 3.7
+dist: xenial
+sudo: true
 
-jobs:
-  include:
-    - python: 3.6
-    - python: 3.7
-      dist: xenial
-      sudo: true
+
+# 0.5 jobs, stages, and matrix
+env:
+  - TOXENV=flake8
+  - TOXENV=manifest
+  - TOXENV=mypy
+  - TOXENV=vulture
+  - TOXENV=doc8
+  - TOXENV=readme
+  - TOXENV=docs
+  - TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
+  - TOXENV=py DB=sqlite
 
 matrix:
   allow_failures:
@@ -53,9 +51,7 @@ before_script:
 
 # 6. script
 script:
-    # - tox
-    - python --version
-    - pip --version
+    - tox
 
 
 # 7. before_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ cache: pip
 
 # 4. install
 install:
-    - pip install tox coverage codecov
+    - sh -c 'if [ "$TOXENV" = "py" ]; then pip install tox codecov; else pip install tox; fi'
 
 
 # 5. before_script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,86 @@
-sudo: false
-cache: pip
+# Organize the .travis.yml by the steps in the build lifecycle
+# https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle
 
-language: python
+# 0. language and environment
+langauge: python
 
-python:
-    - 3.6
+python: "3.7"
+dist: xenial
+sudo: true
 
-services:
-  - postgresql
 
-matrix:
+# 0.5 jobs and matrix
+jobs:
   include:
-    - env: TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
-    - env: TOXENV=py DB=sqlite
+    # lint stage
+    - stage: lint
+      env: TOXENV=flake8
     - env: TOXENV=manifest
-    - env: TOXENV=flake8
     - env: TOXENV=mypy
     - env: TOXENV=vulture
-    - env: TOXENV=doc8
-    - env: TOXENV=rst-lint
+
+    # docs stage
+    - stage: docs
+      env: TOXENV=doc8
     - env: TOXENV=readme
     - env: TOXENV=docs
-  allow_failures:
+
+    # test stage
+    - stage: test
+      env: TOXENV=py DB=postgres OCSPDASH_TEST_CONNECTOR=psycopg2 OCSPDASH_TEST_CONNECTION=postgresql+psycopg2://travis@localhost/tests
+      services: postgresql
+    - env: TOXENV=py DB=sqlite
+
+matrix:
+  allow-failures:
     - env: TOXENV=vulture
 
+
+# 1. apt addons
+
+
+# 2. cache components
+cache: pip
+
+
+# 3. before_install
+
+
+# 4. install
 install:
     - pip install tox codecov coverage
 
+
+# 5. before_script
 before_script:
   - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'DROP DATABASE IF EXISTS tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'DROP DATABASE IF EXISTS tests_tmp;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'CREATE DATABASE tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'CREATE DATABASE tests_tmp;' -U postgres; fi"
 
+
+# 6. script
 script:
     - tox
 
+
+# 7. before_cache
+
+
+# 8. after_success/after_failure
 after_success:
     - tox -e coverage-report
     - codecov
+
+
+# 9. before_deploy
+
+
+# 10. deploy
+
+
+# 11. after_deploy
+
+
+# 12. after_script
+

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ python-jose = "*"
 requests = "*"
 sqlalchemy = "*"
 tqdm = "*"
+"e1839a8" = {editable = true, path = "."}
 
 [dev-packages]
 check-manifest = "*"
@@ -43,7 +44,3 @@ vulture = "*"
 
 [requires]
 python_version = "3.6"
-
-[dev-packages.e1839a8]
-path = "."
-editable = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ef9701921538dc00b4e6eca881084fd5414da195e1ff9c1f714448fd6a54d8d1"
+            "sha256": "2ed22c3063b03bc4420e64be667e3dca472e0688440b8828c395aa8dd6da0d11"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -150,6 +150,10 @@
                 "sha256:4b8ce6f33633c9dd9175b228d21c00c801b6bd0327747cd5e17fc2da934c3a69"
             ],
             "version": "==2.3.1"
+        },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
         },
         "ecdsa": {
             "hashes": [
@@ -391,43 +395,6 @@
             ],
             "version": "==0.7.11"
         },
-        "argon2-cffi": {
-            "hashes": [
-                "sha256:05dd15949be3a7d9f65807fe58fad70526023a319747054bb89da209c4071a33",
-                "sha256:07480018d77f4c7447924e6c44c5ba1789a918413fe3efaa391a097958bbd9f6",
-                "sha256:10e702dbd98a2148d22de9524a605021bdc55d05304beb90ea801ba58c4a4f1e",
-                "sha256:131effd5eabbe08649bc672b5d602fd6e2772b03cfec2ddb2795f9d9babe3fba",
-                "sha256:3f3b48b4802e98bb9692d72108ecad2fecea969c254c17660b70ce5730bbe4a6",
-                "sha256:4c510232a96e991079a743a9310d3c9a014856cdbca644fccc496db2a1ff0e17",
-                "sha256:5f1099b0f5ee4a7148bbd323503983aa4387ab16769ff9b5c51d26f6b0f1719e",
-                "sha256:67452b1f10e873ececcea657c25d063e4bb4007e115227a53157369de5848992",
-                "sha256:77a3d50e6325df79499e1220b7c38adbd30588c2f6d7c2d764fddb2d3b02e650",
-                "sha256:7e4b75611b73f53012117ad21cdde7a17b32d1e99ff6799f22d827eb83a2a59b",
-                "sha256:7f4b6d7c38258e76c1db293a6cf55b7e31701927fc773c5108e57578c7f8e09a",
-                "sha256:82db759b8a495aaed51aec4762b0f44e5e7ad80256e8baf512ae70cdb3b28c50",
-                "sha256:92b3f8f93b19081d520d911f1ce5902693edeeab2181c08aa0bb4130adba51aa",
-                "sha256:93f631fa567dbf948f26874476c9e9afb51e0a835372bf1a319df0c5aa071bfb",
-                "sha256:9befaa6d9798d9771b8176174ba82160beaf1dcdbcc63cd2dc5212f723e5e2a3",
-                "sha256:a14e6d99787a2972d3802615911770fcba9c904401fb0dfb60bdeb250b4c5110",
-                "sha256:c60764fe7f62cc52a74f326e366c60f7aa33a1586c8d02107394a01ae9db6e91",
-                "sha256:cba2c8c539bed691513ae1bcd5a7da632d2aa2410d8b8ebdf56026eac7e2193f",
-                "sha256:d79c918cf8bf981cd23b43a1a547cd1eececb77f3607ba9fa7c0ec01bf1f05a5",
-                "sha256:dc3028ec541146924e3c45973b458a7acf390b9e9ee0b64a13ac0853109a69bc",
-                "sha256:eb3fcb55224a47b8d50830561977c64761eaad9e349af0b2241eab089af44a14",
-                "sha256:f732ca584e81491cc11e3d12e18cbd8c63e137b3f461f378426a6fdaaef47fb0",
-                "sha256:fcd5681388d1f18e4a7ee3ff7a9b68650bc04db044b5a0a832728cbce182806d"
-            ],
-            "index": "pypi",
-            "version": "==18.1.0"
-        },
-        "asn1crypto": {
-            "hashes": [
-                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
-                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
-            ],
-            "index": "pypi",
-            "version": "==0.24.0"
-        },
         "atomicwrites": {
             "hashes": [
                 "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
@@ -449,57 +416,12 @@
             ],
             "version": "==2.6.0"
         },
-        "censys": {
-            "hashes": [
-                "sha256:7e5f623fbdc2ce1dcf3ef531e63ba486f7e255f20c4d4006b4f70b6d59a78534"
-            ],
-            "index": "pypi",
-            "version": "==0.0.8"
-        },
         "certifi": {
             "hashes": [
                 "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
                 "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
             "version": "==2018.4.16"
-        },
-        "cffi": {
-            "hashes": [
-                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
-                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
-                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
-                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
-                "sha256:3bb6bd7266598f318063e584378b8e27c67de998a43362e8fce664c54ee52d30",
-                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
-                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
-                "sha256:495c5c2d43bf6cebe0178eb3e88f9c4aa48d8934aa6e3cddb865c058da76756b",
-                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
-                "sha256:57b2533356cb2d8fac1555815929f7f5f14d68ac77b085d2326b571310f34f6e",
-                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
-                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
-                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
-                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
-                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
-                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
-                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
-                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
-                "sha256:a6a5cb8809091ec9ac03edde9304b3ad82ad4466333432b16d78ef40e0cce0d5",
-                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
-                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
-                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
-                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
-                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
-                "sha256:ca1bd81f40adc59011f58159e4aa6445fc585a32bb8ac9badf7a2c1aa23822f2",
-                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
-                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
-                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
-                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
-                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
-                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
-                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
-            ],
-            "markers": "platform_python_implementation != 'pypy'",
-            "version": "==1.11.5"
         },
         "chardet": {
             "hashes": [
@@ -515,14 +437,6 @@
             ],
             "index": "pypi",
             "version": "==0.37"
-        },
-        "click": {
-            "hashes": [
-                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
-                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
-            ],
-            "index": "pypi",
-            "version": "==6.7"
         },
         "coverage": {
             "hashes": [
@@ -558,31 +472,6 @@
             "index": "pypi",
             "version": "==4.5.1"
         },
-        "cryptography": {
-            "hashes": [
-                "sha256:3f3b65d5a16e6b52fba63dc860b62ca9832f51f1a2ae5083c78b6840275f12dd",
-                "sha256:5251e7de0de66810833606439ca65c9b9e45da62196b0c88bfadf27740aac09f",
-                "sha256:551a3abfe0c8c6833df4192a63371aa2ff43afd8f570ed345d31f251d78e7e04",
-                "sha256:5cb990056b7cadcca26813311187ad751ea644712022a3976443691168781b6f",
-                "sha256:60bda7f12ecb828358be53095fc9c6edda7de8f1ef571f96c00b2363643fa3cd",
-                "sha256:64b5c67acc9a7c83fbb4b69166f3105a0ab722d27934fac2cb26456718eec2ba",
-                "sha256:6fef51ec447fe9f8351894024e94736862900d3a9aa2961528e602eb65c92bdb",
-                "sha256:77d0ad229d47a6e0272d00f6bf8ac06ce14715a9fd02c9a97f5a2869aab3ccb2",
-                "sha256:808fe471b1a6b777f026f7dc7bd9a4959da4bfab64972f2bbe91e22527c1c037",
-                "sha256:9b62fb4d18529c84b961efd9187fecbb48e89aa1a0f9f4161c61b7fc42a101bd",
-                "sha256:9e5bed45ec6b4f828866ac6a6bedf08388ffcfa68abe9e94b34bb40977aba531",
-                "sha256:9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63",
-                "sha256:abd070b5849ed64e6d349199bef955ee0ad99aefbad792f0c587f8effa681a5e",
-                "sha256:ba6a774749b6e510cffc2fb98535f717e0e5fd91c7c99a61d223293df79ab351",
-                "sha256:c332118647f084c983c6a3e1dba0f3bcb051f69d12baccac68db8d62d177eb8a",
-                "sha256:d6f46e862ee36df81e6342c2177ba84e70f722d9dc9c6c394f9f1f434c4a5563",
-                "sha256:db6013746f73bf8edd9c3d1d3f94db635b9422f503db3fc5ef105233d4c011ab",
-                "sha256:f57008eaff597c69cf692c3518f6d4800f0309253bb138b526a37fe9ef0c7471",
-                "sha256:f6c821ac253c19f2ad4c8691633ae1d1a17f120d5b01ea1d256d7b602bc59887"
-            ],
-            "index": "pypi",
-            "version": "==2.2.2"
-        },
         "doc8": {
             "hashes": [
                 "sha256:2df89f9c1a5abfb98ab55d0175fed633cae0cf45025b8b1e0ee5ea772be28543",
@@ -598,23 +487,6 @@
                 "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
             ],
             "version": "==0.14"
-        },
-        "dominate": {
-            "hashes": [
-                "sha256:4b8ce6f33633c9dd9175b228d21c00c801b6bd0327747cd5e17fc2da934c3a69"
-            ],
-            "version": "==2.3.1"
-        },
-        "e1839a8": {
-            "editable": true,
-            "path": "."
-        },
-        "ecdsa": {
-            "hashes": [
-                "sha256:40d002cf360d0e035cf2cb985e1308d41aaa087cbfc135b2dc2d844296ea546c",
-                "sha256:64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa"
-            ],
-            "version": "==0.13"
         },
         "flake8": {
             "hashes": [
@@ -654,50 +526,6 @@
             ],
             "version": "==1.0.2"
         },
-        "flasgger": {
-            "hashes": [
-                "sha256:1c9c03a4b55b60688f2bb2c2d8ff4534cb18eda70fd02973141be8c3bde586b3",
-                "sha256:efee892b0554c60f716b441ee78fddcaf7af20bc764696d9eecd6a389fb7f195"
-            ],
-            "index": "pypi",
-            "version": "==0.9.0"
-        },
-        "flask": {
-            "hashes": [
-                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
-                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
-            ],
-            "index": "pypi",
-            "version": "==1.0.2"
-        },
-        "flask-admin": {
-            "hashes": [
-                "sha256:e3a8268fdb6c271a44196de7f2a85faff886df18061d337e66b4b3c80e9c4f23"
-            ],
-            "index": "pypi",
-            "version": "==1.5.1"
-        },
-        "flask-bootstrap": {
-            "hashes": [
-                "sha256:cb08ed940183f6343a64e465e83b3a3f13c53e1baabb8d72b5da4545ef123ac8"
-            ],
-            "index": "pypi",
-            "version": "==3.3.7.1"
-        },
-        "flask-sqlalchemy": {
-            "hashes": [
-                "sha256:3bc0fac969dd8c0ace01b32060f0c729565293302f0c4269beed154b46bec50b",
-                "sha256:5971b9852b5888655f11db634e87725a9031e170f37c0ce7851cf83497f56e53"
-            ],
-            "index": "pypi",
-            "version": "==2.3.2"
-        },
-        "future": {
-            "hashes": [
-                "sha256:e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb"
-            ],
-            "version": "==0.16.0"
-        },
         "idna": {
             "hashes": [
                 "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
@@ -712,33 +540,12 @@
             ],
             "version": "==1.0.0"
         },
-        "itsdangerous": {
-            "hashes": [
-                "sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
-            ],
-            "version": "==0.24"
-        },
         "jinja2": {
             "hashes": [
                 "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
                 "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
             ],
             "version": "==2.10"
-        },
-        "jsonlines": {
-            "hashes": [
-                "sha256:0ebd5b0c3efe0d4b5018b320fb0ee1a7b680ab39f6eb853715859f818d386cc8",
-                "sha256:43b8d5588a9d4862c8a4a49580e38e20ec595aee7ad6fe469b10fb83fbefde88"
-            ],
-            "index": "pypi",
-            "version": "==1.2.0"
-        },
-        "jsonschema": {
-            "hashes": [
-                "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08",
-                "sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"
-            ],
-            "version": "==2.6.0"
         },
         "markupsafe": {
             "hashes": [
@@ -752,13 +559,6 @@
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
-        },
-        "mistune": {
-            "hashes": [
-                "sha256:b4c512ce2fc99e5a62eb95a4aba4b73e5f90264115c40b70a21e1f7d4e0eac91",
-                "sha256:bc10c33bfdcaa4e749b779f62f60d6e12f8215c46a292d05e486b869ae306619"
-            ],
-            "version": "==0.8.3"
         },
         "more-itertools": {
             "hashes": [
@@ -776,43 +576,12 @@
             "index": "pypi",
             "version": "==0.620"
         },
-        "netaddr": {
-            "hashes": [
-                "sha256:38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd",
-                "sha256:56b3558bd71f3f6999e4c52e349f38660e54a7a8a9943335f73dfc96883e08ca"
-            ],
-            "version": "==0.7.19"
-        },
-        "ocspbuilder": {
-            "hashes": [
-                "sha256:945629537ac6d6960a7413fd32fc49448a442f9dfd87f6de5c239e89ed853a0d",
-                "sha256:ea5b6fbe86eef9bbf33c76c1aee54420163d3d90cb722ddb831f97b2419b772f"
-            ],
-            "index": "pypi",
-            "version": "==0.10.2"
-        },
-        "oscrypto": {
-            "hashes": [
-                "sha256:84fb7cc3a1cca317bce778223a553cf4841e78de658bda7ff96f3afc640ed597",
-                "sha256:9e4c548c1bee575ee3c61fa56b0dd612db85016b4ab403763b22961c8ca05147"
-            ],
-            "index": "pypi",
-            "version": "==0.19.1"
-        },
         "packaging": {
             "hashes": [
                 "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
                 "sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b"
             ],
             "version": "==17.1"
-        },
-        "passlib": {
-            "hashes": [
-                "sha256:3d948f64138c25633613f303bcc471126eae67c04d5e3f6b7b8ce6242f8653e0",
-                "sha256:43526aea08fa32c6b6dbbbe9963c4c767285b78147b7437597f992812f69d280"
-            ],
-            "index": "pypi",
-            "version": "==1.7.1"
         },
         "pbr": {
             "hashes": [
@@ -845,25 +614,12 @@
             "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7'",
             "version": "==1.5.4"
         },
-        "pyasn1": {
-            "hashes": [
-                "sha256:a66dcda18dbf6e4663bde70eb30af3fc4fe1acb2d14c4867a861681887a5f9a2",
-                "sha256:fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc"
-            ],
-            "version": "==0.4.3"
-        },
         "pycodestyle": {
             "hashes": [
                 "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],
             "version": "==2.3.1"
-        },
-        "pycparser": {
-            "hashes": [
-                "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
-            ],
-            "version": "==2.18"
         },
         "pydocstyle": {
             "hashes": [
@@ -903,36 +659,12 @@
             "index": "pypi",
             "version": "==3.6.3"
         },
-        "python-jose": {
-            "hashes": [
-                "sha256:e06dd2e5e9125da79b519ff2652b8c666d64a5ea228fcd9862e0b29a534ccc53",
-                "sha256:e8255fb3cc524c04f4c790547a6215468f2a32d3a866424175523359e69f3aeb"
-            ],
-            "index": "pypi",
-            "version": "==3.0.0"
-        },
         "pytz": {
             "hashes": [
                 "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
                 "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
             ],
             "version": "==2018.5"
-        },
-        "pyyaml": {
-            "hashes": [
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
-                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
-            ],
-            "version": "==3.13"
         },
         "requests": {
             "hashes": [
@@ -948,13 +680,6 @@
             ],
             "index": "pypi",
             "version": "==1.1.3"
-        },
-        "rsa": {
-            "hashes": [
-                "sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5",
-                "sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd"
-            ],
-            "version": "==3.4.2"
         },
         "six": {
             "hashes": [
@@ -972,11 +697,10 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:85f7e32c8ef07f4ba5aeca728e0f7717bef0789fba8458b8d9c5c294cad134f3",
-                "sha256:d45480a229edf70d84ca9fae3784162b1bc75ee47e480ffe04a4b7f21a95d76d"
+                "sha256:a765c6db1e5b62aae857697cd4402a5c1a315a7b0854bbcd0fc8cdc524da5896"
             ],
             "index": "pypi",
-            "version": "==1.7.5"
+            "version": "==1.7.6"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -993,13 +717,6 @@
             ],
             "version": "==1.1.0"
         },
-        "sqlalchemy": {
-            "hashes": [
-                "sha256:72325e67fb85f6e9ad304c603d83626d1df684fdf0c7ab1f0352e71feeab69d8"
-            ],
-            "index": "pypi",
-            "version": "==1.2.10"
-        },
         "stevedore": {
             "hashes": [
                 "sha256:e3d96b2c4e882ec0c1ff95eaebf7b575a779fd0ccb4c741b9832bed410d58b3d",
@@ -1014,14 +731,6 @@
             ],
             "index": "pypi",
             "version": "==3.1.2"
-        },
-        "tqdm": {
-            "hashes": [
-                "sha256:224291ee0d8c52d91b037fd90806f48c79bcd9994d3b0abc9e44b946a908fccd",
-                "sha256:77b8424d41b31e68f437c6dd9cd567aebc9a860507cb42fbd880a5f822d966fe"
-            ],
-            "index": "pypi",
-            "version": "==4.23.4"
         },
         "typed-ast": {
             "hashes": [
@@ -1065,12 +774,6 @@
             ],
             "version": "==16.0.0"
         },
-        "visitor": {
-            "hashes": [
-                "sha256:2c737903b2b6864ebc6167eef7cf3b997126f1aa94bdf590f90f1436d23e480a"
-            ],
-            "version": "==0.1.3"
-        },
         "vulture": {
             "hashes": [
                 "sha256:28f82ac4749a72050910f70ea250a9ab8c4f1d015197d032c773e560b868d72c",
@@ -1078,20 +781,6 @@
             ],
             "index": "pypi",
             "version": "==0.28"
-        },
-        "werkzeug": {
-            "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
-            ],
-            "version": "==0.14.1"
-        },
-        "wtforms": {
-            "hashes": [
-                "sha256:0cdbac3e7f6878086c334aa25dc5a33869a3954e9d1e015130d65a69309b3b61",
-                "sha256:e3ee092c827582c50877cdbd49e9ce6d2c5c1f6561f849b3b068c1b8029626f1"
-            ],
-            "version": "==2.2.1"
         }
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -i https://pypi.org/simple
+-e .
 argon2-cffi==18.1.0
 asn1crypto==0.24.0
 censys==0.0.8
@@ -29,11 +30,11 @@ passlib==1.7.1
 pyasn1==0.4.3
 pycparser==2.18
 python-jose==3.0.0
-pyyaml==3.12
+pyyaml==3.13
 requests==2.19.1
 rsa==3.4.2
 six==1.11.0
-sqlalchemy==1.2.9
+sqlalchemy==1.2.10
 tqdm==4.23.4
 urllib3==1.23
 visitor==0.1.3


### PR DESCRIPTION
Make Python 3.7 the default on Travis and only run 3.6 for the tests, not the linters.